### PR TITLE
feat: add --version/-v flag to display version and exit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "long-run-command-mcp",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "long-run-command-mcp",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "long-run-command-mcp",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "long-run-command-mcp",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "long-run-command-mcp",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "MCP server for executing predefined long-running commands with output logging",
   "main": "dist/long-run-command-mcp.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "long-run-command-mcp",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "MCP server for executing predefined long-running commands with output logging",
   "main": "dist/long-run-command-mcp.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "clean": "rm -rf dist && rm tsconfig.tsbuildinfo",
     "debug": "npx @modelcontextprotocol/inspector tsx src/long-run-command-mcp.ts -c config.example.json",
     "debug:released": "npx @modelcontextprotocol/inspector npx -y long-run-command-mcp@latest -c config.example.json",
+    "debug:version": "npx @modelcontextprotocol/inspector npx -y long-run-command-mcp@0.2.0 -c config.example.json",
     "lint": "npx biome check --write ./src",
     "check": "npm run check:lint && npm run check:type",
     "check:lint": "npx biome check ./src",

--- a/src/config/ConfigManager.test.ts
+++ b/src/config/ConfigManager.test.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import type { Config } from "./ConfigManager";
 import {
   getAvailableKeys,

--- a/src/executor/CommandExecutor.test.ts
+++ b/src/executor/CommandExecutor.test.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import type { Config } from "../config/ConfigManager";
 import { execute } from "./CommandExecutor";
 

--- a/src/logger/LogWriter.test.ts
+++ b/src/logger/LogWriter.test.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
 import { Readable } from "node:stream";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createLogPaths, writeStreams } from "./LogWriter";
 
 describe("LogWriter", () => {

--- a/src/long-run-command-mcp.ts
+++ b/src/long-run-command-mcp.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { startServer } from "./server";
-import { readFileSync } from "fs";
-import { join } from "path";
 
 function getVersion(): string {
   const packageJsonPath = join(__dirname, "..", "package.json");

--- a/src/long-run-command-mcp.ts
+++ b/src/long-run-command-mcp.ts
@@ -1,25 +1,43 @@
 #!/usr/bin/env node
 
 import { startServer } from "./server";
+import { readFileSync } from "fs";
+import { join } from "path";
 
-function parseArgs(): string {
+function getVersion(): string {
+  const packageJsonPath = join(__dirname, "..", "package.json");
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
+  return packageJson.version;
+}
+
+function parseArgs(): { configPath: string; showVersion: boolean } {
   const args = process.argv.slice(2);
   let configPath = "./config.json";
+  let showVersion = false;
 
   for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--version" || args[i] === "-v") {
+      showVersion = true;
+      break;
+    }
     if (args[i] === "--config" || args[i] === "-c") {
       if (i + 1 < args.length) {
         configPath = args[i + 1];
-        break;
       }
     }
   }
 
-  return configPath;
+  return { configPath, showVersion };
 }
 
 async function main(): Promise<void> {
-  const configPath = parseArgs();
+  const { configPath, showVersion } = parseArgs();
+
+  if (showVersion) {
+    console.log(getVersion());
+    process.exit(0);
+  }
+
   const stopServer = await startServer(configPath);
   let stopping = false;
 


### PR DESCRIPTION
## Summary
- Add `--version` and `-v` flags to display version number and exit immediately
- Parse version from package.json dynamically
- Add `debug:version` npm script for testing specific package versions

## Purpose
This change addresses issues with `npx` version-specific execution by allowing the tool to return its version without attempting to start the MCP server or load configuration files.

## Test plan
- [x] Run `node dist/long-run-command-mcp.js --version` to verify version display
- [x] Run `node dist/long-run-command-mcp.js -v` to verify short flag works
- [x] Verify server still starts normally without version flag
- [x] Test with `npx -y long-run-command-mcp@0.2.0 --version` after publishing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a --version / -v flag to print the package version and exit.
- Chores
  - Bumped package version to 0.2.1.
  - Added an npm script (debug:version) to help debug the package using an example config.
- Tests
  - Cleaned up unused test imports in several test files (no behavioral changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->