### PR TITLE
feat: Add support for additional arguments and convert paths to absolute

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ Create a `config.json` file to define your commands:
     "deploy_staging": {
       "workdir": "/home/user/project",
       "command": "./scripts/deploy.sh staging"
+    },
+    "npm_script": {
+      "workdir": "/home/user/project",
+      "command": "npm run",
+      "additionalArgs": true
     }
   }
 }
@@ -63,11 +68,14 @@ Create a `config.json` file to define your commands:
 
 ### Configuration Options
 
-- `outputdir`: Directory where log files will be stored (absolute path recommended)
+- `outputdir`: Directory where log files will be stored (supports both relative and absolute paths)
 - `commands`: Object containing command configurations
   - Key: Command identifier used to execute the command
-  - `workdir`: Working directory for command execution (absolute path)
+  - `workdir`: Working directory for command execution (supports both relative and absolute paths)
   - `command`: The actual command to execute
+  - `additionalArgs` (optional): Boolean flag to allow passing additional arguments at runtime (default: false)
+
+**Note on Paths:** Both `outputdir` and `workdir` support relative paths. When relative paths are used, they are resolved relative to the configuration file's location.
 
 ## How It Works
 
@@ -78,7 +86,9 @@ This server dynamically generates tools based on your configuration. Each comman
 - **Tool Name Format:** `run_<command_key>`
 - **Special Characters:** Replaced with underscores (e.g., `build:prod` → `run_build_prod`)
 - **Tool Description:** Includes the command and working directory
-- **Parameters:** None required - each tool executes its predefined command
+- **Parameters:** 
+  - None required for standard commands
+  - `additionalArgs` (string array): Available when `additionalArgs: true` is set in the command configuration
 
 ### Tool Response Format
 
@@ -101,6 +111,7 @@ With the configuration shown above, you would get these tools:
 - `run_build_frontend` - Executes `npm run build` in `/home/user/project/frontend`
 - `run_test_backend` - Executes `pytest tests/` in `/home/user/project/backend`
 - `run_deploy_staging` - Executes `./scripts/deploy.sh staging` in `/home/user/project`
+- `run_npm_script` - Executes `npm run` with additional arguments in `/home/user/project`
 
 ## Example Usage
 
@@ -121,7 +132,13 @@ Here's how to use this MCP server with Claude:
    ```
    Claude can execute `run_build_frontend` followed by `run_test_backend`.
 
-4. **Check command output:**
+4. **Execute commands with additional arguments:**
+   ```
+   "Run the npm dev script"
+   ```
+   Claude will use the `run_npm_script` tool with `additionalArgs: ["dev"]` to execute `npm run dev`.
+
+5. **Check command output:**
    ```
    "Show me the output from the build"
    ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "long-run-command-mcp",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "long-run-command-mcp",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "long-run-command-mcp",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "MCP server for executing predefined long-running commands with output logging",
   "main": "./dist/long-run-command-mcp.js",
   "bin": {

--- a/src/config/ConfigManager.test.ts
+++ b/src/config/ConfigManager.test.ts
@@ -34,10 +34,14 @@ describe("ConfigManager", () => {
 
       await fs.writeFile(testConfigPath, JSON.stringify(testConfig, null, 2));
       const config = await loadConfig(testConfigPath);
-      
+
       // Check that paths are converted to absolute paths
-      expect(config.outputdir).toBe(path.resolve(path.dirname(testConfigPath), "./output"));
-      expect(config.commands.test.workdir).toBe(path.resolve(path.dirname(testConfigPath), "./"));
+      expect(config.outputdir).toBe(
+        path.resolve(path.dirname(testConfigPath), "./output"),
+      );
+      expect(config.commands.test.workdir).toBe(
+        path.resolve(path.dirname(testConfigPath), "./"),
+      );
       expect(config.commands.test.command).toBe("echo test");
     });
 

--- a/src/config/ConfigManager.test.ts
+++ b/src/config/ConfigManager.test.ts
@@ -34,7 +34,11 @@ describe("ConfigManager", () => {
 
       await fs.writeFile(testConfigPath, JSON.stringify(testConfig, null, 2));
       const config = await loadConfig(testConfigPath);
-      expect(config).toEqual(testConfig);
+      
+      // Check that paths are converted to absolute paths
+      expect(config.outputdir).toBe(path.resolve(path.dirname(testConfigPath), "./output"));
+      expect(config.commands.test.workdir).toBe(path.resolve(path.dirname(testConfigPath), "./"));
+      expect(config.commands.test.command).toBe("echo test");
     });
 
     it("should throw error when outputdir is missing", async () => {

--- a/src/config/ConfigManager.ts
+++ b/src/config/ConfigManager.ts
@@ -71,17 +71,20 @@ export async function loadConfig(configPath: string): Promise<Config> {
     const content = await fs.readFile(absolutePath, "utf-8");
     const parsedConfig = JSON.parse(content);
     const validatedConfig = validateConfig(parsedConfig);
-    
+
     // Convert relative paths to absolute paths
-    validatedConfig.outputdir = path.resolve(configDir, validatedConfig.outputdir);
-    
+    validatedConfig.outputdir = path.resolve(
+      configDir,
+      validatedConfig.outputdir,
+    );
+
     for (const key in validatedConfig.commands) {
       validatedConfig.commands[key].workdir = path.resolve(
-        configDir, 
-        validatedConfig.commands[key].workdir
+        configDir,
+        validatedConfig.commands[key].workdir,
       );
     }
-    
+
     return validatedConfig;
   } catch (error) {
     if (

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -61,7 +61,6 @@ describe("startServer", () => {
       {
         type: "object",
         properties: {},
-        additionalProperties: false,
       },
       expect.any(Function),
     );
@@ -71,7 +70,6 @@ describe("startServer", () => {
       {
         type: "object",
         properties: {},
-        additionalProperties: false,
       },
       expect.any(Function),
     );

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,17 +19,32 @@ function createCommandTool(
   const command = getCommand(config, key);
   const safeKey = key.replace(/[^a-zA-Z0-9_-]/g, "_");
 
+  const schema = command.additionalArgs
+    ? {
+        type: "object" as const,
+        properties: {
+          additionalArgs: {
+            type: "array" as const,
+            items: { type: "string" as const },
+            description: "Additional arguments to pass to the command",
+          },
+        },
+      }
+    : {
+        type: "object" as const,
+        properties: {},
+      };
+
   mcpServer.tool(
     `run_${safeKey}`,
-    `Execute ${key} command: ${command.command} (workdir: ${command.workdir})`,
-    {
-      type: "object",
-      properties: {},
-      additionalProperties: false,
-    },
-    async () => {
+    `Execute ${key} command: ${command.command} (workdir: ${command.workdir})${command.additionalArgs ? " - supports additional arguments" : ""}`,
+    schema,
+    async (args: any) => {
       try {
-        const result = await execute({ key }, config);
+        const result = await execute(
+          { key, additionalArgs: args?.additionalArgs },
+          config,
+        );
 
         return {
           content: [


### PR DESCRIPTION
## Summary
- Added support for additional arguments in command execution
- Implemented automatic conversion of relative paths to absolute paths for better reliability

## Changes
- **Additional Arguments Support**: Commands can now accept dynamic arguments when `additionalArgs: true` is set in configuration
- **Path Resolution**: Both `workdir` and `outputdir` are now automatically converted to absolute paths relative to the config file location
- **Schema Updates**: Updated MCP tool schemas to include optional `additionalArgs` parameter for enabled commands

## Test Plan
- [x] All existing tests pass
- [x] Updated ConfigManager tests to verify absolute path conversion
- [x] Build and type checks pass successfully
- [x] Lint checks pass

## Configuration Example
```json
{
  "commands": {
    "example": {
      "command": "npm run",
      "workdir": "./",
      "additionalArgs": true
    }
  }
}
```

With this configuration, the MCP tool can be called with additional arguments that will be appended to the command.